### PR TITLE
Update requirements.txt for recipe-handler

### DIFF
--- a/src/recipe-handler/requirements.txt
+++ b/src/recipe-handler/requirements.txt
@@ -10,3 +10,4 @@ singledispatch==3.4.0.3
 six==1.12.0
 tqdm==4.31.1
 webcolors==1.8.1
+mxp==0.1.2


### PR DESCRIPTION
When running make in recipe-handler the following error occurs : 
mkdir -p out/
touch out/
mkdir -p out/iswc/
. env/bin/activate; PYTHON37 recipe.py job iswc data/recipe1m-ex-limited.json data/usda-pairs.csv data/foodon-pairs.csv out/iswc/ --cutoff 99999999999999
Traceback (most recent call last):
  File "recipe.py", line 4, in <module>
    import sources
  File "/home/abruyat/FoodKG/foodkg.github.io/src/recipe-handler/sources.py", line 18, in <module>
    import mxp
ModuleNotFoundError: No module named 'mxp'
make: *** [out/iswc/] Error 1

Adding "mxp==0.1.2" to requirements.txt solve the issue